### PR TITLE
consolidations, withdrawals: Remove type byte prefix altogether

### DIFF
--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -29,8 +29,6 @@
 #define INPUT_SIZE 96    ;; the size of (source ++ target)
 #define RECORD_SIZE 116  ;; the size of (address ++ source ++ target)
 
-#define REQUEST_TYPE 0x02
-
 ;; -----------------------------------------------------------------------------
 ;; PROGRAM START ---------------------------------------------------------------
 ;; -----------------------------------------------------------------------------
@@ -222,11 +220,6 @@ read_requests:
   push MAX_PER_BLOCK    ;; [count, head_idx, tail_idx]
 
 begin_loop:
-  ;; Store request type prefix into the output buffer.
-  push1 REQUEST_TYPE    ;; [type, count, head_idx, tail_idx]
-  push 0                ;; [offset, type, count, head_idx, tail_idx]
-  mstore8               ;; [count, head_idx, tail_idx]
-
   ;; Push initial loop index.
   push 0                ;; [i, count, head_idx, tail_idx]
 
@@ -243,8 +236,6 @@ accum_loop:
   dup1                  ;; [i, i, count, head_idx, tail_idx]
   push RECORD_SIZE      ;; [size, i, i, count, head_idx, tail_idx]
   mul                   ;; [offset, i, count, head_idx, tail_idx]
-  push 1                ;; [1, offset, i, count, head_idx, tail_idx]
-  add                   ;; [record_offset, i, count, head_idx, tail_idx]
 
   ;; Determine the storage slot of the address for this iteration. This value is
   ;; also the base for the other storage slots containing the source and the target
@@ -407,8 +398,6 @@ store_excess:
   ;; Return the requests.
   push RECORD_SIZE      ;; [record_size, count]
   mul                   ;; [size, count]
-  push 1                ;; [1, size, count]
-  add                   ;; [size+1, count]
   push0                 ;; [0, size]
   return                ;; []
 

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -39,8 +39,6 @@
 #define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
 #define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)
 
-#define REQUEST_TYPE 0x01
-
 ;; -----------------------------------------------------------------------------
 ;; PROGRAM START ---------------------------------------------------------------
 ;; -----------------------------------------------------------------------------
@@ -222,11 +220,6 @@ read_requests:
   push MAX_PER_BLOCK    ;; [count, head_idx, tail_idx]
 
 begin_loop:
-  ;; Store request type prefix into the output buffer.
-  push1 REQUEST_TYPE    ;; [type, count, head_idx, tail_idx]
-  push 0                ;; [offset, type, count, head_idx, tail_idx]
-  mstore8               ;; [count, head_idx, tail_idx]
-
   ;; Push initial loop index.
   push 0                ;; [i, count, head_idx, tail_idx]
 
@@ -243,8 +236,6 @@ accum_loop:
   dup1                  ;; [i, i, count, head_idx, tail_idx]
   push RECORD_SIZE      ;; [size, i, i, count, head_idx, tail_idx]
   mul                   ;; [offset, i, count, head_idx, tail_idx]
-  push 1                ;; [1, offset, i, count, head_idx, tail_idx]
-  add                   ;; [record_offset, i, count, head_idx, tail_idx]
 
   ;; Determine the storage slot of the address for this iteration. This value is
   ;; also the base for the other two storage slots containing the public key and
@@ -425,8 +416,6 @@ store_excess:
   ;; Return the withdrawal requests.
   push RECORD_SIZE      ;; [record_size, count]
   mul                   ;; [size, count]
-  push 1                ;; [1, size, count]
-  add                   ;; [size+1, count]
   push0                 ;; [0, size]
   return                ;; []
 


### PR DESCRIPTION
It seems from latest discussions that we will be removing the byte-prefix altogether. So this PR modification on top of https://github.com/lightclient/sys-asm/pull/25 changes to remove the type prefix from both contracts.

I'm trying to mine a good address in the meantime so we can have a set address for devnet-4, let me know if this is ok.